### PR TITLE
Compensate for empty wp_title on homepage

### DIFF
--- a/src/Cgit/AcfSeo.php
+++ b/src/Cgit/AcfSeo.php
@@ -137,6 +137,11 @@ class AcfSeo
      */
     public function optimizeTitle($title, $sep, $location)
     {
+        if ($title == '') {
+            // Empty title usually means the homepage
+            $title = get_the_title();
+        }
+
         $seo_title = get_field('seo_title', $this->getId());
 
         if (!$this->isPost() || !$seo_title) {


### PR DESCRIPTION
wp_title returns an empty string on a home page - I suggest this alt to optimizeTitle to retrieve the page title.